### PR TITLE
feat(player): add function to retrieve ingame name of a player by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,14 @@ Sets the global error level.
 
 Returns the global error level as `number`.
 
+#### `getPlayerIngameName(playerId: number): string`
+
+Returns the Teamspeak name of a player by their player ID. If the player or the name is not found, an empty string is returned and an error is logged in Console.
+
+| Parameter | Type     | Description        |
+|-----------|----------|--------------------|
+| playerId  | `number` | The player source  |
+
 </details>
 
 # Events
@@ -650,7 +658,6 @@ The event is triggered when the player changes the channel to the ingame or excl
 | channelType | `string` | `INGAME_CHANNEL` when moving into the ingame channel and `EXCLUDED_CHANNEL` when moving into a excluded channel. |
 
 </details>
-
 <details>
 <summary style="font-size: x-large">Server</summary>
 

--- a/apps/yaca-server/src/yaca/main.ts
+++ b/apps/yaca-server/src/yaca/main.ts
@@ -1,4 +1,12 @@
-import { GLOBAL_ERROR_LEVEL_STATE_NAME, getGlobalErrorLevel, initLocale, loadConfig, setGlobalErrorLevel, VOICE_RANGE_STATE_NAME, locale } from '@yaca-voice/common'
+import {
+    GLOBAL_ERROR_LEVEL_STATE_NAME,
+    getGlobalErrorLevel,
+    initLocale,
+    loadConfig,
+    locale,
+    setGlobalErrorLevel,
+    VOICE_RANGE_STATE_NAME
+} from '@yaca-voice/common'
 import {
     type DataObject,
     defaultServerConfig,

--- a/apps/yaca-server/src/yaca/main.ts
+++ b/apps/yaca-server/src/yaca/main.ts
@@ -1,4 +1,4 @@
-import { GLOBAL_ERROR_LEVEL_STATE_NAME, getGlobalErrorLevel, initLocale, loadConfig, setGlobalErrorLevel, VOICE_RANGE_STATE_NAME } from '@yaca-voice/common'
+import { GLOBAL_ERROR_LEVEL_STATE_NAME, getGlobalErrorLevel, initLocale, loadConfig, setGlobalErrorLevel, VOICE_RANGE_STATE_NAME, locale } from '@yaca-voice/common'
 import {
     type DataObject,
     defaultServerConfig,
@@ -201,11 +201,11 @@ export class YaCAServerModule {
         exports('getPlayerIngameName', (playerId: number) => {
             const player = this.getPlayer(playerId)
             if (!player) {
-                console.error(`[YaCA] Player with ID ${playerId} not found.`)
+                console.error(locale('player_not_found', playerId))
                 return ''
             }
             if (!player.voiceSettings?.ingameName) {
-                console.error(`[YaCA] Ingame name for player ${playerId} is not set.`)
+                console.error(locale('ingamename_not_set', playerId))
                 return ''
             }
             return player.voiceSettings.ingameName

--- a/apps/yaca-server/src/yaca/main.ts
+++ b/apps/yaca-server/src/yaca/main.ts
@@ -5,7 +5,7 @@ import {
     loadConfig,
     locale,
     setGlobalErrorLevel,
-    VOICE_RANGE_STATE_NAME
+    VOICE_RANGE_STATE_NAME,
 } from '@yaca-voice/common'
 import {
     type DataObject,

--- a/apps/yaca-server/src/yaca/main.ts
+++ b/apps/yaca-server/src/yaca/main.ts
@@ -191,6 +191,25 @@ export class YaCAServerModule {
          * @returns {number} - The global error level.
          */
         exports('getGlobalErrorLevel', () => getGlobalErrorLevel())
+
+        /**
+         * Gibt den Ingame-Namen eines Spielers zurück.
+         *
+         * @param {number} playerId - Die ID des Spielers.
+         * @returns {string} - Der Ingame-Name oder leerer String bei Fehler.
+         */
+        exports('getPlayerIngameName', (playerId: number) => {
+            const player = this.getPlayer(playerId)
+            if (!player) {
+                console.error(`[YaCA] Spieler mit ID ${playerId} nicht gefunden.`)
+                return ''
+            }
+            if (!player.voiceSettings?.ingameName) {
+                console.error(`[YaCA] Ingame-Name für Spieler ${playerId} nicht gesetzt.`)
+                return ''
+            }
+            return player.voiceSettings.ingameName
+        })
     }
 
     /**

--- a/apps/yaca-server/src/yaca/main.ts
+++ b/apps/yaca-server/src/yaca/main.ts
@@ -193,19 +193,19 @@ export class YaCAServerModule {
         exports('getGlobalErrorLevel', () => getGlobalErrorLevel())
 
         /**
-         * Gibt den Ingame-Namen eines Spielers zurück.
+         * Returns the ingame name of a player.
          *
-         * @param {number} playerId - Die ID des Spielers.
-         * @returns {string} - Der Ingame-Name oder leerer String bei Fehler.
+         * @param {number} playerId - The ID of the player.
+         * @returns {string} - The ingame name or an empty string if not found.
          */
         exports('getPlayerIngameName', (playerId: number) => {
             const player = this.getPlayer(playerId)
             if (!player) {
-                console.error(`[YaCA] Spieler mit ID ${playerId} nicht gefunden.`)
+                console.error(`[YaCA] Player with ID ${playerId} not found.`)
                 return ''
             }
             if (!player.voiceSettings?.ingameName) {
-                console.error(`[YaCA] Ingame-Name für Spieler ${playerId} nicht gesetzt.`)
+                console.error(`[YaCA] Ingame name for player ${playerId} is not set.`)
                 return ''
             }
             return player.voiceSettings.ingameName

--- a/assets/yaca-voice/locales/de.json
+++ b/assets/yaca-voice/locales/de.json
@@ -29,5 +29,7 @@
     "change_voice_range_via_mousewheel": "Sprachreichweite je 1 Meter ändern",
 
     "radio_not_activated": "Das Funkgerät ist nicht aktiviert!",
-    "radio_channel_invalid": "Ungültiger Funkkanal!"
+    "radio_channel_invalid": "Ungültiger Funkkanal!",
+    "player_not_found": "Spieler mit der ID %s wurde nicht gefunden.",
+    "ingamename_not_set": "Ingame-Name für Spieler %s ist nicht gesetzt."
 }

--- a/assets/yaca-voice/locales/en.json
+++ b/assets/yaca-voice/locales/en.json
@@ -29,5 +29,7 @@
     "change_voice_range_via_mousewheel": "Change voice range by 1 meter",
 
     "radio_not_activated": "Your radio is not activated!",
-    "radio_channel_invalid": "The radio channel is invalid!"
+    "radio_channel_invalid": "The radio channel is invalid!",
+    "player_not_found": "Player with ID %s was not found.",
+    "ingamename_not_set": "Ingame name for player %s is not set."
 }


### PR DESCRIPTION
Dieser PR fügt einen serverseitigen Export getPlayerIngameName hinzu, mit dem der Ingame-Name eines Spielers anhand seiner Spieler-ID abgerufen werden kann. Falls der Spieler oder der Name nicht gefunden wird, gibt die Funktion einen leeren String zurück und schreibt eine Fehlermeldung in die Server-Konsole. Dadurch wird die Fehlerbehandlung verbessert und die API bleibt konsistent.
Änderungen:
Export getPlayerIngameName in der YaCA-Servermodul-Klasse implementiert
Fehlerbehandlung: Rückgabe eines leeren Strings und Logging bei Fehlern