### PR TITLE
feat(radio): include player ID in isRadioReceiving event

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ The event is triggered when a player starts or stops receiving on the radio.
 |-----------|-----------|------------------------------------------------|
 | state     | `boolean` | the new receiver state                         |
 | channel   | `number`  | the channel from which the player is receiving |
+| playerId  | `number`  | the server ID of the player who is talking     |
 
 ### yaca:external:notification
 

--- a/apps/yaca-client/src/yaca/radio.ts
+++ b/apps/yaca-client/src/yaca/radio.ts
@@ -298,7 +298,7 @@ export class YaCAClientRadioModule {
                         this.playersWithShortRange.set(target, frequency)
                     }
 
-                    emit('yaca:external:isRadioReceiving', true, channel)
+                    emit('yaca:external:isRadioReceiving', true, channel, target)
                     this.clientModule.saltyChatBridge?.handleRadioReceivingStateChange(true, channel)
                 } else {
                     this.playersInRadioChannel.get(channel)?.delete(target)
@@ -308,7 +308,7 @@ export class YaCAClientRadioModule {
 
                     const inRadio = this.playersInRadioChannel.get(channel)?.size || 0
                     const state = inRadio > 0
-                    emit('yaca:external:isRadioReceiving', state, channel)
+                    emit('yaca:external:isRadioReceiving', state, channel, target)
                     this.clientModule.saltyChatBridge?.handleRadioReceivingStateChange(state, channel)
                 }
             },


### PR DESCRIPTION
This pull request introduces a small enhancement to the radio module of the YaCA client by including the `playerId` (server ID of the player who is talking) in events related to radio receiving state changes. This provides additional context for external consumers of the event.

### Enhancements to radio event handling:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R634): Updated the documentation to include the new `playerId` parameter in the `yaca:external:isRadioReceiving` event, describing it as the server ID of the player who is talking.
* [`apps/yaca-client/src/yaca/radio.ts`](diffhunk://#diff-0b41c3f15446f6880d5f3b16396d7686a6e009d852105d77ce8abc17f38bf5f1L301-R301): Modified the `emit` calls for the `yaca:external:isRadioReceiving` event to include the `target` parameter (representing the `playerId`) when emitting the event. [[1]](diffhunk://#diff-0b41c3f15446f6880d5f3b16396d7686a6e009d852105d77ce8abc17f38bf5f1L301-R301) [[2]](diffhunk://#diff-0b41c3f15446f6880d5f3b16396d7686a6e009d852105d77ce8abc17f38bf5f1L311-R311)