### PR TITLE
added playerId to client:yaca:leaveRadioChannel & send yaca:external:…

### DIFF
--- a/apps/yaca-client/src/yaca/radio.ts
+++ b/apps/yaca-client/src/yaca/radio.ts
@@ -364,11 +364,7 @@ export class YaCAClientRadioModule {
          * @param {number | number[]} client_ids - The IDs of the clients.
          * @param {string} frequency - The frequency of the radio.
          */
-        onNet('client:yaca:leaveRadioChannel', (client_ids: number | number[], frequency: string) => {
-            if (!Array.isArray(client_ids)) {
-                client_ids = [client_ids]
-            }
-
+        onNet('client:yaca:leaveRadioChannel', (client_id: number, _playerId: number, frequency: string) => {
             const channel = this.findRadioChannelByFrequency(frequency)
             if (!channel) {
                 return
@@ -379,7 +375,7 @@ export class YaCAClientRadioModule {
                 return
             }
 
-            if (client_ids.includes(playerData.clientId)) {
+            if (playerData.clientId == client_id) {
                 this.setRadioFrequency(channel, '0')
 
                 if (this.radioTowerCalculation.has(channel)) {
@@ -392,7 +388,7 @@ export class YaCAClientRadioModule {
                 base: { request_type: 'INGAME' },
                 comm_device_left: {
                     comm_type: YacaFilterEnum.RADIO,
-                    client_ids,
+                    client_ids: [client_id],
                     channel,
                 },
             })

--- a/apps/yaca-client/src/yaca/radio.ts
+++ b/apps/yaca-client/src/yaca/radio.ts
@@ -375,7 +375,7 @@ export class YaCAClientRadioModule {
                 return
             }
 
-            if (playerData.clientId == client_id) {
+            if (playerData.clientId === client_id) {
                 this.setRadioFrequency(channel, '0')
 
                 if (this.radioTowerCalculation.has(channel)) {

--- a/apps/yaca-server/src/yaca/radio.ts
+++ b/apps/yaca-server/src/yaca/radio.ts
@@ -259,16 +259,16 @@ export class YaCAServerRadioModule {
             this.radioFrequencyMap.set(frequency, new Map<number, { muted: boolean }>())
         }
 
-        const radioFrequencyMap = this.radioFrequencyMap.get(frequency)!
+        const radioFrequencyMap = this.radioFrequencyMap.get(frequency)
 
-        radioFrequencyMap.set(src, { muted: false })
+        radioFrequencyMap?.set(src, { muted: false })
 
         player.radioSettings.frequencies[channel] = frequency
 
         emitNet('client:yaca:setRadioFreq', src, channel, frequency)
         emit('yaca:external:changedRadioFrequency', src, channel, frequency)
 
-        if (player.voicePlugin) {
+        if (player.voicePlugin && radioFrequencyMap) {
             const playersArray = []
             for (const [key] of radioFrequencyMap) {
                 const target = this.serverModule.getPlayer(key)

--- a/apps/yaca-server/src/yaca/radio.ts
+++ b/apps/yaca-server/src/yaca/radio.ts
@@ -258,12 +258,29 @@ export class YaCAServerRadioModule {
         if (!this.radioFrequencyMap.has(frequency)) {
             this.radioFrequencyMap.set(frequency, new Map<number, { muted: boolean }>())
         }
-        this.radioFrequencyMap.get(frequency)?.set(src, { muted: false })
+
+        const radioFrequencyMap = this.radioFrequencyMap.get(frequency)!
+
+        radioFrequencyMap.set(src, { muted: false })
 
         player.radioSettings.frequencies[channel] = frequency
 
         emitNet('client:yaca:setRadioFreq', src, channel, frequency)
         emit('yaca:external:changedRadioFrequency', src, channel, frequency)
+
+        if (player.voicePlugin) {
+            const playersArray = []
+            for (const [key] of radioFrequencyMap) {
+                const target = this.serverModule.getPlayer(key)
+                if (!target) {
+                    continue
+                }
+
+                playersArray.push(key)
+            }
+
+            triggerClientEvent('yaca:external:updateRadioFrequency', playersArray, player.voicePlugin.clientId, player.voicePlugin.playerId, frequency)
+        }
     }
 
     /**
@@ -308,7 +325,9 @@ export class YaCAServerRadioModule {
         }
 
         if (player.voicePlugin) {
-            triggerClientEvent('client:yaca:leaveRadioChannel', playersArray, player.voicePlugin.clientId, frequency)
+            //see apps\yaca-server\src\yaca\main.ts - addNewPlayer
+            //playerId is for lua code...
+            triggerClientEvent('client:yaca:leaveRadioChannel', playersArray, player.voicePlugin.clientId, player.voicePlugin.playerId, frequency)
         }
 
         allPlayersInChannel.delete(src)


### PR DESCRIPTION
Added a way for resources to correctly keep track of client joining/leaving the radio.

```
RegisterNetEvent("client:yaca:leaveRadioChannel", function(clientId, playerId, frequency)
    if playerId == GetPlayerServerId(PlayerId()) then return end
    print("Player " .. playerId .. " joined the radio")
end)

RegisterNetEvent("yaca:external:updateRadioFrequency", function(clientId, playerId, frequency)
    if playerId == GetPlayerServerId(PlayerId()) then return end
    print("Player " .. playerId .. " left the radio")
end)
``` 