### PR TITLE
fix(client): automatically reconnect to the voice plugin after websocket close

### DIFF
--- a/apps/yaca-client/src/yaca/main.ts
+++ b/apps/yaca-client/src/yaca/main.ts
@@ -72,6 +72,9 @@ export class YaCAClientModule {
     maxVoiceRange = -1
     rangeIndex: number
     rangeInterval: CitizenTimer | null = null
+    reconnectTimeout: CitizenTimer | null = null
+    reconnectAttempts = 0
+    readonly maxReconnectAttempts = 10
     visualVoiceRangeTimeout: CitizenTimer | null = null
     visualVoiceRangeTick: CitizenTimer | null = null
     voiceRangeViaMouseWheelTick: CitizenTimer | null = null
@@ -668,10 +671,18 @@ export class YaCAClientModule {
                     this.setCurrentPluginState(YacaPluginStates.NOT_CONNECTED)
 
                     console.error('[YACA-Websocket]: client disconnected', code, reason)
+
+                    this.scheduleReconnect()
                 })
 
                 this.websocket.on('open', () => {
                     this.setCurrentPluginState(YacaPluginStates.CONNECTED)
+
+                    this.reconnectAttempts = 0
+                    if (this.reconnectTimeout) {
+                        clearTimeout(this.reconnectTimeout)
+                        this.reconnectTimeout = null
+                    }
 
                     if (this.firstConnect) {
                         this.initRequest(dataObj)
@@ -813,6 +824,31 @@ export class YaCAClientModule {
         }
 
         return null
+    }
+
+    /**
+     * Schedules a reconnect attempt to the voice plugin after the websocket connection was lost.
+     * Uses an exponential backoff (capped at 30s) so a persistently unreachable plugin doesn't spam reconnect attempts.
+     */
+    scheduleReconnect() {
+        if (this.reconnectTimeout) {
+            return
+        }
+
+        if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+            console.error(`[YACA-Websocket]: giving up reconnecting to the voice plugin after ${this.reconnectAttempts} attempts`)
+            this.notification(locale('connect_error'), YacaNotificationType.ERROR)
+            return
+        }
+
+        const delay = Math.min(1000 * 2 ** this.reconnectAttempts, 30000)
+        this.reconnectAttempts++
+
+        this.reconnectTimeout = setTimeout(() => {
+            this.reconnectTimeout = null
+            console.log(`[YACA-Websocket]: attempting to reconnect to the voice plugin (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`)
+            this.websocket.start()
+        }, delay)
     }
 
     /**


### PR DESCRIPTION
## Problem

Some players occasionally get stuck after the websocket connection between the FiveM client resource and the local YaCA voice plugin drops (plugin crash, TS/Mumble connection loss, etc.). The only way for them to recover was to fully restart the game and rejoin the server.

## Root cause

In `apps/yaca-client/src/yaca/main.ts`, the `client:yaca:init` handler only ever calls `websocket.start()` once, inside an `if (!this.websocket.initialized)` guard. `initialized` is set to `true` on the first successful connect and never reset. The `close` event handler only logs the disconnect and sets the plugin state to `NOT_CONNECTED` — it never triggers a new `start()` call.

Since `websocket.initialized` stays `true` forever, that guard can never run again, so nothing re-establishes the connection. Any subsequent `client:yaca:init` from the server falls through to `initRequest()`, which calls `websocket.send()` — a no-op once `readyState !== 1`. The `rangeInterval` also keeps firing every 250ms sending doomed no-op writes. The server-side reconnect path (`playerReconnect()` via `server:yaca:wsReady`) already exists but is unreachable, since it depends on the client's `open` event firing again, which never happens.

## Fix

Add a `scheduleReconnect()` method that:
- Retries `websocket.start()` with exponential backoff (1s, 2s, 4s, ... capped at 30s), up to 10 attempts.
- Is triggered from the `close` handler.
- Resets the attempt counter (and cancels any pending retry) once the `open` event fires again.
- Notifies the player via the existing `connect_error` locale string if all retries are exhausted.

This reuses the existing (previously unreachable) server-side `playerReconnect()` / `wsReady` flow rather than duplicating the init logic — once `websocket.start()` succeeds again, the existing `open` handler already does the right thing (re-sends `INIT` on first connect, or emits `server:yaca:wsReady` for the server to re-sync the player).

## Testing

- `pnpm run typecheck` — passes
- `pnpm biome check` — passes
- `pnpm run build` — passes (client + server build successfully)
- Not yet tested against a live TS/Mumble plugin disconnect in-game — I don't have a way to reliably reproduce the underlying plugin crash in this environment. Happy to test further or adjust the backoff/attempt-limit values based on maintainer feedback.

## Notes

I don't have push access to this repo, so I opened this from a fork. Let me know if you'd like a different approach (e.g. unlimited retries, different backoff shape, or resetting `websocket.initialized` instead of adding a dedicated reconnect path).